### PR TITLE
Add setAtIndex method to update value at a specific index

### DIFF
--- a/dsa/java/02_doubly_linked_list/DoublyLinkedList.jsh
+++ b/dsa/java/02_doubly_linked_list/DoublyLinkedList.jsh
@@ -140,6 +140,20 @@ public class DoublyLinkedList {
         return current;
     }
 
+    public boolean setAtIndex(int index, int value) {
+        // Step 1: Use getAtIndex to get the node at the specified index
+        Node nodeToUpdate = getAtIndex(index);
+
+        // Step 2: Check if the node exists (valid index)
+        if (nodeToUpdate == null) {
+            return false; // Index is out of bounds, return false
+        }
+
+        // Step 3: Update the node's value
+        nodeToUpdate.value = value;
+        return true; // Update was successful, return true
+    }
+
     public void printList() {
         // Start at the head of the list
         Node current = head;


### PR DESCRIPTION
The setAtIndex method allows updating the value of a node at a given index in the doubly linked list. It validates the index and returns a boolean indicating success or failure. This enhancement improves usability by providing an efficient way to modify node values directly.