### PR TITLE
Add pattern matching test cases for list structures

### DIFF
--- a/Python/structural_pattern_matching/pattern_matching_v1.py
+++ b/Python/structural_pattern_matching/pattern_matching_v1.py
@@ -1,0 +1,19 @@
+# Test case for the provided pattern-matching code
+
+subject = [3.5, 7, 0]
+
+# declarative
+match subject:
+    case list([int() | float() as x, int() | float() as y, 0]):
+        print(f"declarative Point({x}, {y})")
+
+# Test case for imperative pattern matching
+if (
+        isinstance(subject, list) and
+        len(subject) == 3 and
+        (isinstance(subject[0], (int, float))) and
+        (isinstance(subject[1], (int, float))) and
+        subject[2] == 0
+):
+    x, y = subject[0], subject[1]
+    print(f"imperative Point({x}, {y})")


### PR DESCRIPTION
Introduce both declarative and imperative approaches to pattern matching. The tests handle a specific list structure with two numbers and a trailing zero. This demonstrates Python's match-case syntax alongside equivalent imperative logic.