### PR TITLE
Add constant value pattern matching examples for enums

### DIFF
--- a/Python/structural_pattern_matching/ConstantValuePatterns.jsh
+++ b/Python/structural_pattern_matching/ConstantValuePatterns.jsh
@@ -1,0 +1,19 @@
+enum Color {
+    RED, GREEN, BLUE;
+}
+
+public class Main {
+    static void processColor(Color color) {
+        switch (color) {
+            case RED -> System.out.println("It's red!");
+            case GREEN -> System.out.println("It's green!");
+            case BLUE -> System.out.println("It's blue!");
+            default -> System.out.println("Unknown color");
+        }
+    }
+
+    public static void main(String[] args) {
+        processColor(Color.RED);   // Output: It's red!
+        processColor(Color.GREEN); // Output: It's green!
+    }
+}

--- a/Python/structural_pattern_matching/constant_value_patterns_enums.py
+++ b/Python/structural_pattern_matching/constant_value_patterns_enums.py
@@ -1,0 +1,20 @@
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+def process_color(color):
+    match color:
+        case Color.RED:
+            print("It's red!")
+        case Color.GREEN:
+            print("It's green!")
+        case Color.BLUE:
+            print("It's blue!")
+        case _:
+            print("Unknown color")
+
+process_color(Color.RED)   # Output: It's red!
+process_color(Color.GREEN) # Output: It's green!


### PR DESCRIPTION
Introduces examples of structural pattern matching for enums in both Java and Python. Demonstrates handling specific enum cases and a default case for unmatched values.