### PR TITLE
Update Node value type and add put() method to HashTable

### DIFF
--- a/dsa/java/06_hash_tables/HashTable.jsh
+++ b/dsa/java/06_hash_tables/HashTable.jsh
@@ -4,10 +4,10 @@ public class HashTable {
 
     class Node {
         String key;
-        String value;
+        int value;
         Node next;
 
-        public Node(String key, String value) {
+        public Node(String key, int value) {
             this.key = key;
             this.value = value;
         }
@@ -26,6 +26,20 @@ public class HashTable {
         }
         // Force positivity using bitwise AND
         return hash & Integer.MAX_VALUE;
+    }
+
+    public void put(String key, int value) {
+        int hash = hash(key);
+        Node newNode = new Node(key,value);
+        if (table[hash] == null) {
+            table[hash] = newNode;
+        } else {
+            Node current = table[hash];
+            while (current.next != null) {
+                current = current.next;
+            }
+            current.next = newNode;
+        }
     }
 
     public void printHashTable() {


### PR DESCRIPTION
Changed the `value` type in `Node` from String to int for improved type consistency. Introduced the `put()` method to insert key-value pairs into the hash table, ensuring proper handling of collisions through chaining.