### PR TITLE
Add probing type support to OpenAddressingHashTable

### DIFF
--- a/dsa/java/06_hash_tables/ChainedHashTable.jsh
+++ b/dsa/java/06_hash_tables/ChainedHashTable.jsh
@@ -14,7 +14,7 @@ public class ChainedHashTable {
         }
     }
 
-    public HashTable(int size) {
+    public ChainedHashTable(int size) {
         this.size = size;
         this.table = new Node[size];
     }


### PR DESCRIPTION
Implemented support for multiple probing strategies: linear, quadratic, and double hashing. Refactored probing logic and constructors to utilize the selected probing type. Added `printTable` method for easier inspection of the hash table state.