### PR TITLE
Add recursive contains method to BST

### DIFF
--- a/dsa/java/05_BST/BST.jsh
+++ b/dsa/java/05_BST/BST.jsh
@@ -200,4 +200,18 @@ import java.util.stream.Collectors;public class BinarySearchTree {
         return false;
     }
 
+    private boolean rContains(Node node, int value) {
+        if (node == null) {
+            return false;
+        }
+        if (node.value == value) {
+            return true;
+        }
+        return rContains(node.value < value ? node.right : node.left, value);
+    }
+
+    public boolean rContains(int value) {
+        return rContains(root, value);
+    }
+
 }


### PR DESCRIPTION
Implements a recursive method `rContains` to check for the presence of a value in the binary search tree. This enhances functionality by providing an alternative to the existing iterative approach.