### PR TITLE
Add recursive insert method to BST

### DIFF
--- a/dsa/java/05_BST/BST.jsh
+++ b/dsa/java/05_BST/BST.jsh
@@ -214,4 +214,23 @@ import java.util.stream.Collectors;public class BinarySearchTree {
         return rContains(root, value);
     }
 
+    private Node rInsert(Node currentNode, int value) {
+        // base case
+        if (currentNode == null) {
+            return new Node(value);
+        }
+        if (value < currentNode.value) {
+            currentNode.left = rInsert(currentNode.left, value);
+        } else if (value > currentNode.value) {
+            currentNode.right = rInsert(currentNode.right, value);
+        }
+        return currentNode;
+    }
+
+    public void rInsert(int value) {
+        if (root == null) {
+            root = new Node(value);
+        }
+        rInsert(root, value);
+    }
 }


### PR DESCRIPTION
Implements a recursive method `rInsert` to add values to the binary search tree. This complements the existing functionality and provides a recursive alternative for inserting nodes into the tree.