### PR TITLE
Add BFS traversal method to BinarySearchTree class

### DIFF
--- a/dsa/java/05_BST/BST.jsh
+++ b/dsa/java/05_BST/BST.jsh
@@ -1,4 +1,6 @@
 import java.util.Arrays;
+import java.util.Queue;
+import java.util.LinkedList;
 import java.util.stream.Collectors;
 
 public class BinarySearchTree {
@@ -270,4 +272,27 @@ public class BinarySearchTree {
     public void deleteNode(int value) {
         root = deleteNode(root, value);
     }
+
+    // ------ tree traversal ---------------------
+    // BFS
+    public ArrayList<Integer> bfs() {
+        Node current = root;
+        // using Javas implemented Queue for a LinkedList
+        Queue<Node> queue = new LinkedList<>();
+        ArrayList<Integer> result = new ArrayList<>();
+        queue.add(current);
+
+        while (!queue.isEmpty()) {
+            current = queue.remove();
+            result.add(current.value);
+            if (current.left != null) {
+                queue.add(current.left);
+            }
+            if (current.right != null) {
+                queue.add(current.right);
+            }
+        }
+        return result;
+    }
+
 }


### PR DESCRIPTION
Introduced a `bfs` method for breadth-first search traversal of the tree. It uses a queue to iterate through nodes level by level and returns the traversal as a list of integers. This enhances tree traversal functionality.